### PR TITLE
Bug fix : method instead of value returned

### DIFF
--- a/degiro_connector/trading/actions/action_confirm_order.py
+++ b/degiro_connector/trading/actions/action_confirm_order.py
@@ -140,7 +140,6 @@ class ActionConfirmOrder(AbstractAction):
         except requests.HTTPError as e:
             status_code = getattr(response_raw, "status_code", "No status_code found.")
             text = getattr(response_raw, "text", "No text found.")
-            response_dict = getattr(response_raw, "json", "No json found.")
             logger.fatal(status_code)
             logger.fatal(text)
             logger.fatal(response_dict)


### PR DESCRIPTION
`response_dict = getattr(response_raw, "json", "No json found.")`
assigns a method to response_dict instead of the value.
response raw for errors has this format :
`{"errors":[{"text":"dummy error message..."}]}`
maybe typing could be done, but would it still be raw ?